### PR TITLE
Invisible characters like <U+001B>

### DIFF
--- a/spec/test.txt
+++ b/spec/test.txt
@@ -1,2 +1,3 @@
 This line contains bad characters. ¦ «
+This line contains invisible characters: 
 This line should not. ?{}[]<>!$%^&/|\_!'"`~;:


### PR DESCRIPTION
They are not highlighted.

for example `gcc` would complain:
![image](https://cloud.githubusercontent.com/assets/2737108/13678518/6ac9971c-e6ef-11e5-992b-586d67dbbfb4.png)
