### PR TITLE
Add `\u2028` character (line separator space)

### DIFF
--- a/lib/highlight-bad-chars.coffee
+++ b/lib/highlight-bad-chars.coffee
@@ -43,6 +43,7 @@ chars = [
   '\u200D', # zero width joiner
   '\u2013',  # en dash
   '\u2014',  # em dash
+  '\u2028',  # line separator space
   '\u202F', # narrow no-break space
   '\u205F', # medium mathematical space
   '\u3000', # ideographic space


### PR DESCRIPTION
This space crashes the new Symfony Yaml Parser (2.8.19). 

Thanks @wengerk

Fixes #11 