### PR TITLE
Fix #7 Persistent prop was removed

### DIFF
--- a/lib/highlight-bad-chars.coffee
+++ b/lib/highlight-bad-chars.coffee
@@ -81,5 +81,5 @@ module.exports = HighlightBadChars =
         @decorations = []
 
         editor.scan badchars, (obj) =>
-          mark = editor.markBufferRange(obj.range, {persistent: false})
+          mark = editor.markBufferRange(obj.range)
           @decorations.push editor.decorateMarker mark, {type: 'highlight', class: 'highlight-bad-chars'}


### PR DESCRIPTION
Persistent property was removed in Atom v1.9.0 and it generates deprecation warnings.