### PR TITLE
Add '\u0003' character (start of text)

### DIFF
--- a/lib/highlight-bad-chars.coffee
+++ b/lib/highlight-bad-chars.coffee
@@ -64,6 +64,7 @@ chars = [
   '\u00B8',  # cadilla
   '\u01C0',  # latin letter dental click
   '\u2223',  # divides
+  '\u0003',  # Start of text
 ]
 
 charRegExp = '[' + chars.join('') + ']'


### PR DESCRIPTION
This character causes issues when loaded in some browsers. It is copied from applications like Adobe Illustrator.